### PR TITLE
Demodulize and underscore class names for the counter field

### DIFF
--- a/lib/mongoid/magic_counter_cache.rb
+++ b/lib/mongoid/magic_counter_cache.rb
@@ -50,7 +50,7 @@ module Mongoid #:nodoc:
         if options[:field]
           counter_name = "#{options[:field].to_s}"
         else
-          counter_name = "#{model_name.downcase}_count"
+          counter_name = "#{model_name.demodulize.underscore}_count"
         end
         after_create  do |doc|
           if doc.embedded?

--- a/spec/models/book.rb
+++ b/spec/models/book.rb
@@ -3,9 +3,11 @@ class Book
   include Mongoid::MagicCounterCache
 
   belongs_to :library
+  embeds_many :foreign_publications, :class_name => "Book::ForeignPublication"
   embeds_many :pages
 
   field :title
+  field :foreign_publication_count, :type => Integer, :default => 0
   field :page_count, :type => Integer, :default => 0
 
   counter_cache :library

--- a/spec/models/book/foreign_publication.rb
+++ b/spec/models/book/foreign_publication.rb
@@ -1,0 +1,9 @@
+class Book
+  class ForeignPublication
+    include Mongoid::Document
+    include Mongoid::MagicCounterCache
+
+    belongs_to :book, :inverse_of => :foreign_publications
+    counter_cache :book
+  end
+end

--- a/spec/mongoid/magic_counter_cache_spec.rb
+++ b/spec/mongoid/magic_counter_cache_spec.rb
@@ -74,6 +74,13 @@ module Mongoid
           library.book_count.should == library.books.entries.size
         end
 
+        it "should by default use demodulized and underscored model names for the count field" do
+          book = library.books.last
+          book.foreign_publication_count.should == 0
+          book.foreign_publications.push( Book::ForeignPublication.new )
+          book.foreign_publication_count.should == 1
+        end
+
         context "when the referenced document has an embedded document" do
 
           let(:page) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Mongoid.configure do |config|
     config.master = Mongo::Connection.new.db(name)
 end
 
-Dir["#{File.dirname(__FILE__)}/models/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/models/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |c|
     c.mock_with :rspec


### PR DESCRIPTION
So that for a class like Person::CloseFriend the field is named "close_friend_count", not "person::closefriend_count".
