### PR TITLE
Don't require bson_ext

### DIFF
--- a/mongoid_magic_counter_cache.gemspec
+++ b/mongoid_magic_counter_cache.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency("mongoid", "~> 2.0") 
   s.add_dependency("rake")
-  s.add_dependency("bson_ext","~> 1.5")
   s.add_development_dependency "rspec"
 end


### PR DESCRIPTION
IMO, it should be up to the application including mongoid_magic_counter_cache to
decide whether or not to use bson_ext.

Also, mongoid 3 no longer uses the bson gems.
