### PR TITLE
Allow mongoid versions up to 3.0.X

### DIFF
--- a/mongoid_magic_counter_cache.gemspec
+++ b/mongoid_magic_counter_cache.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("mongoid", ">= 2.2", "<= 3.0.0.rc")
+  s.add_dependency("mongoid", ">= 2.2", "<= 3.0")
   s.add_dependency("rake")
   s.add_dependency("bson_ext","~> 1.5")
   s.add_development_dependency "rspec"


### PR DESCRIPTION
3.0.0 has been released and specs still pass, so we can now bump this dependency up further. Not sure why I haven't done so right from the get-go – sorry.
