### PR TITLE
Remove mongoid version from gemspec to support both Mongoid 2.x and 3.x

### DIFF
--- a/mongoid_magic_counter_cache.gemspec
+++ b/mongoid_magic_counter_cache.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("mongoid", "~> 3.0.0")
+  s.add_dependency("mongoid")
   s.add_dependency("rake")
   s.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This adds support for Mongoid 2 back.  Pull #9 adds support for Mongoid 3 but removes support for Mongoid 2.  The solution is rather straightforward, just remove the Mongoid version from the gemspec and allow the main project's Gemfile to determine the Mongoid version.
