### PR TITLE
Add if_update option for conditionally updating counter in after_update hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1
+
+* Add :if_update option in order to allow counter to be conditionally increment/decrement counter when an update is made to a referenced/embedded object.
+
 ## v1.0.0
 
 * Remove version dependency to work with rails 4. Breaks compatibility with ruby 1.9.2 and older

--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ end
 
 comment_count will get incremented / decremented only when `:if` condition returns `true`
 
+### Conditional Counter After Update
+
+In conjunction with the conditional counter, if you want to maintain counter after an update to an object, then you can specify it using `:if_update`
+
+Using same example as above, in the referrenced/Embedded document, add an additional condition for counter using `:if_update`
+
+````rb
+class Comment
+  include Mongoid::Document
+  include Mongoid::MagicCounterCache
+
+  belongs_to :post
+
+  field :remark
+  field :is_published, type: Boolean, default: false
+
+  counter_cache :post, :if => Proc.new { |act| (act.is_published)  }, :if_update => Proc.new { |act| act.changes['is_published'] }
+end
+````
+
+When a comment is saved, comment_count will get incremented / decremented if the is_published field is dirty.
+
 ## TODO
 
 1. Add additional options parameters

--- a/lib/mongoid/magic-counter-cache/version.rb
+++ b/lib/mongoid/magic-counter-cache/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module MagicCounterCache
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/lib/mongoid/magic_counter_cache.rb
+++ b/lib/mongoid/magic_counter_cache.rb
@@ -69,6 +69,7 @@ module Mongoid #:nodoc:
         name          = options[:class] || args.first.to_s
         counter_name  = get_counter_name(options)
         condition     = options[:if]
+        update_condition = options[:if_update]
 
         callback_proc = ->(doc, inc) do
           result = condition_result(condition, doc)
@@ -86,8 +87,29 @@ module Mongoid #:nodoc:
           end
         end
 
+        update_callback_proc = ->(doc) do
+          return if condition.nil?
+          return if update_condition.nil? # Don't execute if there is no update condition.
+          return unless update_condition.call(doc) # Determine whether to execute update increment/decrements.
+
+          inc = condition.call(doc) ? 1 : -1
+
+          if doc.embedded?
+            parent = doc._parent
+            if parent.respond_to?(counter_name)
+              increment_association(parent, counter_name.to_sym, inc)
+            end
+          else
+            relation = doc.send(name)
+            if relation && relation.class.fields.keys.include?(counter_name)
+              increment_association(relation, counter_name.to_sym, inc)
+            end
+          end
+        end
+
         after_create( ->(doc) { callback_proc.call(doc,  1) })
         after_destroy(->(doc) { callback_proc.call(doc, -1) })
+        after_update( ->(doc) { update_callback_proc.call(doc) })
 
       end
 

--- a/lib/mongoid_magic_counter_cache/version.rb
+++ b/lib/mongoid_magic_counter_cache/version.rb
@@ -1,3 +1,3 @@
 module MongoidMagicCounterCache
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/models/article.rb
+++ b/spec/models/article.rb
@@ -2,8 +2,10 @@ class Article
   include Mongoid::Document
 
   embeds_many :reviews
+  embeds_many :update_reviews
 
   field :title
   field :review_count, type: Integer, default: 0
+  field :update_review_count, type: Integer, default: 0
 
 end

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -6,4 +6,6 @@ class Post
 
   has_many :comments
 
+  field :update_comment_count, :type => Integer, :default => 0
+  has_many :update_comments
 end

--- a/spec/models/update_comment.rb
+++ b/spec/models/update_comment.rb
@@ -1,0 +1,11 @@
+class UpdateComment
+  include Mongoid::Document
+  include Mongoid::MagicCounterCache
+
+  belongs_to :post
+
+  field :remark
+  field :is_published, type: Boolean, default: false
+
+  counter_cache :post, :if => Proc.new { |act| (act.is_published)  }, :if_update => Proc.new { |act| act.changes['is_published'] }
+end

--- a/spec/models/update_review.rb
+++ b/spec/models/update_review.rb
@@ -1,0 +1,10 @@
+class UpdateReview
+  include Mongoid::Document
+  include Mongoid::MagicCounterCache
+
+  embedded_in   :article
+  counter_cache :article, :if => Proc.new { |act| (act.is_published)  }, :if_update => Proc.new { |act| act.changes['is_published'] }
+
+  field :comment
+  field :is_published, type: Boolean, default: false
+end


### PR DESCRIPTION
This pull builds on top of the conditional update functionality.  It allows updates to the counter to be made when an update has been made to an embedded/referenced object.

Without this pull, the conditional code is sort of incomplete since you will have to manually increment/decrement the counter when you update the field in the embedded/referenced object that the :if condition depends on.

See the new specs I've added - "should increase counter when old unpublished review is published" and "should decrease counter when old published review is unpublished".
